### PR TITLE
Update main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ mmonit_ssl_certificate_key: ''
 
 mmonit_connectors:
   - name: 'Default'
+    scheme: http
     address: '*'
     port: 2811
     processors: 10


### PR DESCRIPTION
Missing default connector's scheme failed task: "Generate setup script" with error: "dict object' has no attribute 'scheme'"